### PR TITLE
[0.1.0] Update Template for Roxy Engine Tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Licenses
 
 --
 
-Roxy Engine Project Template
+Roxy Engine Tests
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,10 @@
-# Roxy Engine Project Template
+# Roxy Engine Tests
 
-The fast way to start building Playdate games using [Roxy](https://github.com/invisiblesloth/roxy-engine). This project template includes the engine as a submodule, a recommended folder structure, and a ~~working~~ *soon to be working* build setup to get your going.
+Unit tests for [Roxy](https://github.com/invisiblesloth/roxy-engine). This project template includes the engine as a submodule and unit tests for each Roxy Engine module and feature.
 
 > **Note:** Roxy is currently in pre-release. Features and APIs may evolve before version 1.0.
 
 ---
-
-## Setup ⚙️
-
-### Create Your Project (Recommended)
-
-1. Click the "Use this template" button above.
-2. Choose "Create a new repository".
-3. Name your project and select visibility (public/private).
-4. Clone your new repository locally:
-   ```bash
-   git clone --recurse-submodules https://github.com/your-username/your-new-repo.git
-   ```
-
-> 💡 The `--recurse-submodules` flag makes sure that Roxy Engine is cloned into `source/libraries/`.
-
-### Manual Download
-
-If you're not using Git:
-
-1. Download this repository as ZIP file and extract it.
-2. Also download [Roxy Engine](https://github.com/invisiblesloth/roxy-engine) and place it in `source/libraries/`.
 
 ## Support 💬
 


### PR DESCRIPTION
### Overview
This update adapts the original `roxy-engine-project-template` for use in the `roxy-engine-tests` repository.

### Key Changes
- Renames project references from "Project Template" to "Roxy Engine Tests".
- Updates the README to reflect the purpose of this repo:
  - Adds reference to Roxy Engine test.
  - Removes setup instructions intended for project bootstrapping.