### PR TITLE
[0.8.0] - Add Asset and Cache Tests, Align Naming and Bump Engine

### DIFF
--- a/source/main.lua
+++ b/source/main.lua
@@ -17,6 +17,8 @@ import "scenes/CameraIntegrationTest"
 import "scenes/RoxySpriteIntegrationTest"
 import "scenes/RoxyAnimationIntegrationTest"
 import "scenes/RoxyActorIntegrationTest"
+import "scenes/CacheIntegrationTest"
+import "scenes/AssetsIntegrationTest"
 r.Scene.registerScenes({
   SceneTest = SceneTest,
   TransitionTest = TransitionTest,
@@ -28,6 +30,8 @@ r.Scene.registerScenes({
   RoxySpriteIntegrationTest = RoxySpriteIntegrationTest,
   RoxyAnimationIntegrationTest = RoxyAnimationIntegrationTest,
   RoxyActorIntegrationTest = RoxyActorIntegrationTest,
+  CacheIntegrationTest = CacheIntegrationTest,
+  AssetsIntegrationTest = AssetsIntegrationTest
 })
 
-r.new(RoxyActorIntegrationTest)
+r.new(AssetsIntegrationTest)

--- a/source/pdxinfo
+++ b/source/pdxinfo
@@ -2,5 +2,5 @@ name=Roxy Engine Test Suite
 author=Invisible Sloth, LLC
 description=Playground to test all the latest Roxy Engine features.
 bundleID=com.invisiblesloth.roxyenginetestsuite
-version=0.7.0
-buildNumber=91
+version=0.8.0
+buildNumber=95

--- a/source/scenes/AssetsIntegrationTest.lua
+++ b/source/scenes/AssetsIntegrationTest.lua
@@ -1,0 +1,158 @@
+-- source/scenes/AssetsIntegrationTest.lua
+
+local pd <const> = playdate
+local Graphics <const> = pd.graphics
+local Assets <const> = roxy.Assets
+
+local tableInsert <const> = table.insert
+local tableRemove <const> = table.remove
+
+local clearScreen <const> = Graphics.clear
+local drawText <const> = Graphics.drawText
+
+local COLOR_WHITE <const> = Graphics.kColorWhite
+local CLEAR_COLOR <const> = COLOR_WHITE
+
+-- ----------------------------------------
+-- Helpers
+-- ----------------------------------------
+
+local logLines = {}
+
+local function ok(msg)
+  tableInsert(logLines, "✔️ " .. msg)
+end
+
+local function fail(msg)
+  tableInsert(logLines, "❌ " .. msg)
+end
+
+local function expect(cond, msg)
+  if cond then ok(msg) else fail(msg) end
+end
+
+local function pruneLog()
+  if #logLines > 60 then
+    tableRemove(logLines, 1)
+  end
+end
+
+-- ----------------------------------------
+-- Class Definition & Init
+-- ----------------------------------------
+
+class("AssetsIntegrationTest").extends(RoxyScene)
+local scene = AssetsIntegrationTest
+
+function scene:init()
+  scene.super.init(self)
+  self.done     = false
+  self.testsRun = false
+end
+
+-- ----------------------------------------
+-- Scene Lifecycle
+-- ----------------------------------------
+
+function scene:enter()
+  scene.super.enter(self)
+  if not self.testsRun then
+    self:runTests()
+    self.testsRun = true
+  end
+end
+
+function scene:update()
+  clearScreen(CLEAR_COLOR)
+
+  -- Draw logs
+  local y = 10
+  for i = 1, math.min(#logLines, 18) do
+    drawText(logLines[i], 10, y)
+    y += 12
+  end
+  if self.done then
+    drawText("*DONE*", 10, 220)
+  end
+end
+
+-- ----------------------------------------
+-- Integration Tests
+-- ----------------------------------------
+
+function scene:runTests()
+  -------------------------------------------------
+  -- (1) isPoolRegistered before and after register
+  -------------------------------------------------
+  expect(not Assets.getIsPoolRegistered("pool1"), "getIsPoolRegistered: false for unregistered")
+
+  -- loader that returns sequential numbers
+  local counter = 0
+  local loader = function()
+    counter += 1; return counter
+  end
+
+  local ok1 = Assets.registerPool("pool1", 2, loader)
+  expect(ok1 == true, "registerPool: registers new pool successfully")
+  expect(Assets.getIsPoolRegistered("pool1"), "getIsPoolRegistered: true after register")
+
+  local okDup = Assets.registerPool("pool1", 1, loader)
+  expect(okDup == false, "registerPool: false when registering duplicate pool")
+
+  -------------------------------------------------
+  -- (2) getAsset consumes initial assets
+  -------------------------------------------------
+  -- initialCount=2, loader called twice at register, assets {1,2}
+  local a1 = Assets.getAsset("pool1")
+  expect(a1 == 2, "getAsset: returns most recently loaded asset (2)")
+  local a2 = Assets.getAsset("pool1")
+  expect(a2 == 1, "getAsset: returns next asset (1)")
+
+  -------------------------------------------------
+  -- (3) getAsset grows pool when empty
+  -------------------------------------------------
+  -- pool.totalSize 2, maxSize default=4, growthFactor=1
+  local a3 = Assets.getAsset("pool1")
+  expect(a3 == 3, "getAsset: grows and returns new asset (3)")
+  local a4 = Assets.getAsset("pool1")
+  expect(a4 == 4, "getAsset: grows again up to maxSize and returns (4)")
+
+  -------------------------------------------------
+  -- (4) getAsset returns nil at max capacity
+  -------------------------------------------------
+  local a5 = Assets.getAsset("pool1")
+  expect(a5 == nil, "getAsset: returns nil when pool empty and at max capacity")
+
+  -------------------------------------------------
+  -- (5) recycleAsset and reuse
+  -------------------------------------------------
+  local okRecFail = Assets.recycleAsset("poolX", {})
+  expect(okRecFail == false, "recycleAsset: false for unregistered pool")
+  local okRecNil = Assets.recycleAsset("pool1", nil)
+  expect(okRecNil == false, "recycleAsset: false for nil asset")
+
+  -- recycle a4 back into pool
+  local okRec = Assets.recycleAsset("pool1", a4)
+  expect(okRec == true, "recycleAsset: true for valid asset")
+  local a6 = Assets.getAsset("pool1")
+  expect(a6 == a4, "getAsset: returns recycled asset first")
+
+  -------------------------------------------------
+  -- (6) clear pools and loader failure handling
+  -------------------------------------------------
+  -- clear internal pools by reassigning a fresh module
+  roxy.Cache = roxy.Cache or {}   -- ensure no conflict
+  roxy.Assets = roxy.Assets or {} -- keep module table
+  -- simulate loader that returns nil
+  local loaderNil = function() return nil end
+  local okReg2 = Assets.registerPool("pool2", 1, loaderNil)
+  -- loader returns nil during registration, initialCount dumps to 0
+  expect(okReg2 == true, "registerPool: still returns true even if loader returns nil")
+  local aNil = Assets.getAsset("pool2")
+  expect(aNil == nil, "getAsset: returns nil if loader fails when growing")
+
+  -- DONE
+  pruneLog()
+  for _, line in ipairs(logLines) do print(line) end
+  self.done = true
+end

--- a/source/scenes/CacheIntegrationTest.lua
+++ b/source/scenes/CacheIntegrationTest.lua
@@ -1,0 +1,155 @@
+-- source/scenes/CacheIntegrationTest.lua
+
+local pd <const> = playdate
+local Graphics <const> = pd.graphics
+local Cache <const> = roxy.Cache
+
+local tableInsert <const> = table.insert
+local tableRemove <const> = table.remove
+
+local clearScreen <const> = Graphics.clear
+local drawText <const> = Graphics.drawText
+
+local COLOR_WHITE <const> = Graphics.kColorWhite
+local CLEAR_COLOR <const> = COLOR_WHITE
+
+-- ----------------------------------------
+-- Helpers
+-- ----------------------------------------
+
+local logLines = {}
+
+local function ok(msg)
+  tableInsert(logLines, "✔️ " .. msg)
+end
+
+local function fail(msg)
+  tableInsert(logLines, "❌ " .. msg)
+end
+
+local function expect(cond, msg)
+  if cond then ok(msg) else fail(msg) end
+end
+
+local function pruneLog()
+  if #logLines > 60 then
+    tableRemove(logLines, 1)
+  end
+end
+
+-- ----------------------------------------
+-- Class Definition & Init
+-- ----------------------------------------
+
+class("CacheIntegrationTest").extends(RoxyScene)
+local scene = CacheIntegrationTest
+
+function scene:init()
+  scene.super.init(self)
+  self.testsRun = false
+  self.done     = false
+end
+
+-- ----------------------------------------
+-- Scene Lifecycle
+-- ----------------------------------------
+
+function scene:enter()
+  scene.super.enter(self)
+  if not self.testsRun then
+    self:runTests()
+    self.testsRun = true
+  end
+end
+
+function scene:update()
+  clearScreen(CLEAR_COLOR)
+
+  -- Draw logs
+  local y = 10
+  for i = 1, math.min(#logLines, 18) do
+    drawText(logLines[i], 10, y)
+    y += 12
+  end
+  if self.done then
+    drawText("*DONE*", 10, 220)
+  end
+end
+
+-- ----------------------------------------
+-- Integration Tests
+-- ----------------------------------------
+
+function scene:runTests()
+  -------------------------------------------------
+  -- (1) newBucket default and custom
+  -------------------------------------------------
+  local b1 = Cache.newBucket()
+  expect(b1.maxCacheSize == 50, "newBucket: default maxCacheSize is 50")
+  local b2 = Cache.newBucket(2)
+  expect(b2.maxCacheSize == 2, "newBucket: custom maxCacheSize")
+
+  -------------------------------------------------
+  -- (2) setMaxCacheSize and eviction
+  -------------------------------------------------
+  Cache.setMaxCacheSize(b2, 1)
+  expect(b2.maxCacheSize == 1, "setMaxCacheSize: sets custom max")
+  Cache.clearCache(b2)
+  Cache.cacheAsset(b2, "k1", function() return "v1" end)
+  Cache.cacheAsset(b2, "k2", function() return "v2" end)
+  expect(not Cache.getIsAssetCached(b2, "k1") and Cache.getIsAssetCached(b2, "k2"),
+    "cacheAsset: evicts LRU when over max")
+
+  -------------------------------------------------
+  -- (3) cacheAsset & getCachedAsset on default bucket
+  -------------------------------------------------
+  Cache.clearCache()
+  local ok1 = Cache.cacheAsset("keyA", function() return "assetA" end)
+  expect(ok1 == true, "cacheAsset: caches new asset on default bucket")
+  expect(Cache.getIsAssetCached("keyA"), "getIsAssetCached: true after cacheAsset")
+  local gotA = Cache.getCachedAsset("keyA")
+  expect(gotA == "assetA", "getCachedAsset: returns correct asset")
+
+  -------------------------------------------------
+  -- (4) getOrLoadAsset behavior
+  -------------------------------------------------
+  Cache.clearCache()
+  local val = Cache.getOrLoadAsset("kX", function() return 123 end)
+  expect(val == 123, "getOrLoadAsset: loads and returns new asset")
+  expect(Cache.getIsAssetCached("kX"), "getOrLoadAsset: caches new asset")
+  local val2 = Cache.getOrLoadAsset("kX", function() error("should not load again") end)
+  expect(val2 == 123, "getOrLoadAsset: returns cached asset without reloading")
+
+  -------------------------------------------------
+  -- (5) getCachedAsset on missing
+  -------------------------------------------------
+  local missing = Cache.getCachedAsset("noKey")
+  expect(missing == nil, "getCachedAsset: nil for missing key")
+
+  -------------------------------------------------
+  -- (6) evictAsset removes and handles non-existent
+  -------------------------------------------------
+  Cache.clearCache()
+  Cache.cacheAsset("kY", function() return "yy" end)
+  expect(Cache.getIsAssetCached("kY"), "cacheAsset: caches kY")
+  local e1 = Cache.evictAsset("kY")
+  expect(e1 == true, "evictAsset: removes existing key")
+  expect(not Cache.getIsAssetCached("kY"), "getIsAssetCached: false after eviction")
+  local e2 = Cache.evictAsset("kY")
+  expect(e2 == false, "evictAsset: returns false when key missing")
+
+  -------------------------------------------------
+  -- (7) clearCache empties
+  -------------------------------------------------
+  Cache.clearCache()
+  Cache.cacheAsset("kA", function() return "a" end)
+  Cache.cacheAsset("kB", function() return "b" end)
+  Cache.clearCache()
+  expect(not Cache.getIsAssetCached("kA") and not Cache.getIsAssetCached("kB"),
+    "clearCache: empties all entries")
+
+  -- DONE
+  pruneLog()
+  for _, line in ipairs(logLines) do print(line) end
+  self.done = true
+end

--- a/source/scenes/RoxySpriteIntegrationTest.lua
+++ b/source/scenes/RoxySpriteIntegrationTest.lua
@@ -34,7 +34,7 @@ end
 
 local function pruneLog()
   if #logLines > 60 then
-    table.remove(logLines, 1)
+    tableRemove(logLines, 1)
   end
 end
 
@@ -77,10 +77,6 @@ function scene:update()
   end
 end
 
-function scene:cleanup()
-  scene.super.cleanup(self)
-end
-
 -- ----------------------------------------
 -- Integration Tests
 -- ----------------------------------------
@@ -88,22 +84,22 @@ end
 function scene:runTests()
   -- (1) Create sprite, check defaults
   local s = RoxySprite()
-  expect(s.name == "RoxySprite",       "default name")
-  expect(s:getIsPaused(),              "paused by default")
-  expect(s._added == false,            "not added initially")
+  expect(s.name == "RoxySprite", "default name")
+  expect(s:getIsPaused(), "paused by default")
+  expect(s._added == false, "not added initially")
   expect(s:getOrientation() == Graphics.kImageUnflipped, "unflipped by default")
 
   -- (2) Test chaining setters
-  expect(s:setZIndex(5) == s,          "setZIndex chains")
-  expect(s:setSize(32, 48) == s,       "setSize chains")
-  expect(s:setCenter(0.5, 0.5) == s,    "setCenter chains")
-  expect(s:moveTo(100, 80) == s,        "moveTo chains")
+  expect(s:setZIndex(5) == s, "setZIndex chains")
+  expect(s:setSize(32, 48) == s, "setSize chains")
+  expect(s:setCenter(0.5, 0.5) == s, "setCenter chains")
+  expect(s:moveTo(100, 80) == s, "moveTo chains")
 
   -- (3) Test add/remove
   s:add()
-  expect(s:isAdded(),                  "isAdded after add()")
+  expect(s:isAdded(), "isAdded after add()")
   s:remove()
-  expect(not s:isAdded(),              "not added after remove()")
+  expect(not s:isAdded(), "not added after remove()")
 
   -- (4) Test flipping
   s:flipX()
@@ -117,19 +113,19 @@ function scene:runTests()
 
   -- (5) Test pause/play/toggle/replay/stop
   -- no animation yet: play/pause should still chain
-  expect(s:play() == s,                "play chains")
-  expect(s:pause() == s,               "pause chains")
-  s:getIsPaused()                         -- no state change
+  expect(s:play() == s, "play chains")
+  expect(s:pause() == s, "pause chains")
+  s:getIsPaused() -- no state change
   s:togglePlayPause():togglePlayPause()
-  expect(true,                         "togglePlayPause chains")
-  expect(s:replay() == s,              "replay chains")
-  expect(s:stop() == s,                "stop chains")
+  expect(true, "togglePlayPause chains")
+  expect(s:replay() == s, "replay chains")
+  expect(s:stop() == s, "stop chains")
 
   -- (6) Test isOnScreen (assuming default camera at 0,0 and display 400×240)
-  s:setSize(10, 10):setCenter(0,0):moveTo(5,5)
-  expect(s:isOnScreen(),               "sprite on screen at (5,5)")
+  s:setSize(10, 10):setCenter(0, 0):moveTo(5, 5)
+  expect(s:isOnScreen(), "sprite on screen at (5,5)")
   s:moveTo(-100, -100)
-  expect(not s:isOnScreen(),           "sprite off-screen at (-100,-100)")
+  expect(not s:isOnScreen(), "sprite off-screen at (-100,-100)")
 
   -- (7) Test drawSpecificFrame & stepFrame warnings (no animation)
   s:drawSpecificFrame(2, true)
@@ -138,7 +134,7 @@ function scene:runTests()
 
   -- (8) Test view = nil hides sprite
   s:setView(nil)
-  expect(not s:isVisible(),            "setView(nil) hides sprite")
+  expect(not s:isVisible(), "setView(nil) hides sprite")
 
   -- DONE
   pruneLog()

--- a/tests/assets/assets_spec.lua
+++ b/tests/assets/assets_spec.lua
@@ -1,0 +1,87 @@
+-- tests/modules/assets_spec.lua
+
+dofile("tests/spec_helper.lua")
+local spy = require("luassert.spy")
+
+describe("roxy.Assets (Asset Pool)", function()
+  local Assets
+
+  before_each(function()
+    -- Reload the Assets module to reset internal pools
+    package.loaded["core.modules.Assets"] = nil
+    import("core.modules.Assets")
+    Assets = roxy.Assets
+  end)
+
+  it("registerPool rejects non-function loader and duplicates", function()
+    -- invalid loader
+    assert.is_false(Assets.registerPool("key", 1, nil))
+    -- valid
+    local loader = function() return {} end
+    assert.is_true(Assets.registerPool("key", 2, loader))
+    -- duplicate key
+    assert.is_false(Assets.registerPool("key", 2, loader))
+  end)
+
+  it("getIsPoolRegistered reports registration status", function()
+    assert.is_false(Assets.getIsPoolRegistered("foo"))
+    Assets.registerPool("foo", 1, function() return 42 end)
+    assert.is_true(Assets.getIsPoolRegistered("foo"))
+  end)
+
+  it("getAsset returns assets, grows pool once, then nil at max", function()
+    -- initialCount=1, default maxSize=2, growthFactor=1
+    local loads = 0
+    local function loader()
+      loads = loads + 1
+      return "A"..loads
+    end
+
+    Assets.registerPool("p", 1, loader)
+
+    -- 1st call: uses preloaded asset
+    local a1 = Assets.getAsset("p")
+    assert.equals("A1", a1)
+    assert.equals(1, loads)
+
+    -- 2nd call: pool empty → grows by 1 (creates A2)
+    local a2 = Assets.getAsset("p")
+    assert.equals("A2", a2)
+    assert.equals(2, loads)
+
+    -- 3rd call: pool at maxSize and empty → returns nil, no new loads
+    local a3 = Assets.getAsset("p")
+    assert.is_nil(a3)
+    assert.equals(2, loads)
+  end)
+
+  it("recycleAsset returns asset to pool for reuse", function()
+    local loads = 0
+    local function loader() loads = loads + 1; return {id = loads} end
+
+    Assets.registerPool("r", 1, loader)
+
+    -- pull first asset
+    local a1 = Assets.getAsset("r")
+    assert.equals(1, loads)
+
+    -- pool empty now; pull again to force growth (makes a2)
+    local a2 = Assets.getAsset("r")
+    assert.equals(2, loads)
+    assert.is_not_nil(a2)
+
+    -- recycle first asset
+    assert.is_true(Assets.recycleAsset("r", a1))
+
+    -- getAsset should now return a1 (no additional load)
+    local a3 = Assets.getAsset("r")
+    assert.equals(2, loads)   -- loader not called again
+    assert.equal(a1, a3)
+  end)
+
+  it("recycleAsset rejects invalid pool or nil asset", function()
+    assert.is_false(Assets.recycleAsset("nope", {}))
+    Assets.registerPool("q", 1, function() return "Z" end)
+    assert.is_false(Assets.recycleAsset("q", nil))
+  end)
+end)

--- a/tests/assets/cache_spec.lua
+++ b/tests/assets/cache_spec.lua
@@ -1,0 +1,143 @@
+-- tests/assets/cache_spec.lua
+
+dofile("tests/spec_helper.lua")
+local spy = require("luassert.spy")
+
+describe("roxy.Cache (LRU cache)", function()
+  local Cache
+  before_each(function()
+    -- Reload the Cache module to reset internal state
+    package.loaded["core.modules.Cache"] = nil
+    import("core.modules.Cache")
+    Cache = roxy.Cache
+  end)
+
+  it("newBucket initializes empty bucket with default max size", function()
+    local bucket = Cache.newBucket()
+    assert.equals(0, bucket.currentSize)
+    assert.equals(50, bucket.maxCacheSize)
+    assert.is_nil(bucket.head)
+    assert.is_nil(bucket.tail)
+    assert.same({}, bucket.cache)
+
+    local bucket2 = Cache.newBucket(10)
+    assert.equals(10, bucket2.maxCacheSize)
+  end)
+
+  it("setMaxCacheSize sets max size and evicts overflows", function()
+    local bucket = Cache.newBucket(2)
+    -- populate via cacheAsset
+    assert.is_true(Cache.cacheAsset(bucket, "a", function() return 1 end))
+    assert.is_true(Cache.cacheAsset(bucket, "b", function() return 2 end))
+    assert.equals(2, bucket.currentSize)
+
+    -- increase limit
+    assert.is_true(Cache.setMaxCacheSize(bucket, 3))
+    assert.equals(3, bucket.maxCacheSize)
+    assert.equals(2, bucket.currentSize)
+
+    -- shrink below current size => evicts from tail
+    assert.is_true(Cache.setMaxCacheSize(bucket, 1))
+    assert.equals(1, bucket.maxCacheSize)
+    assert.equals(1, bucket.currentSize)
+  end)
+
+  it("cacheAsset adds new assets, enforces max size, and rejects invalid", function()
+    local bucket = Cache.newBucket(2)
+    local loadCount = 0
+    local function loader()
+      loadCount = loadCount + 1
+      return {data = true}
+    end
+
+    -- valid adds
+    assert.is_true(Cache.cacheAsset(bucket, "x", loader))
+    assert.equals(1, loadCount)
+    assert.is_not_nil(bucket.cache["x"])
+    assert.equals(1, bucket.currentSize)
+
+    assert.is_true(Cache.cacheAsset(bucket, "y", loader))
+    assert.is_not_nil(bucket.cache["y"])
+    assert.equals(2, bucket.currentSize)
+
+    -- overflow evicts oldest (x)
+    assert.is_true(Cache.cacheAsset(bucket, "z", loader))
+    assert.equals(2, bucket.currentSize)
+    assert.is_nil(bucket.cache["x"])
+    assert.is_not_nil(bucket.cache["z"])
+
+    -- reject duplicate key
+    assert.is_false(Cache.cacheAsset(bucket, "z", loader))
+    -- reject bad key or loader
+    assert.is_false(Cache.cacheAsset(bucket, {}, loader))
+    assert.is_false(Cache.cacheAsset(bucket, "k", nil))
+
+    -- loader returns nil
+    local badLoader = function() return nil end
+    assert.is_false(Cache.cacheAsset(bucket, "bad", badLoader))
+  end)
+
+  it("getCachedAsset returns asset and updates MRU, rejects misses", function()
+    local bucket = Cache.newBucket()
+    Cache.cacheAsset(bucket, "a", function() return "A" end)
+    Cache.cacheAsset(bucket, "b", function() return "B" end)
+    -- initial head should be b
+    assert.equals("b", bucket.head.key)
+
+    local a = Cache.getCachedAsset(bucket, "a")
+    assert.equals("A", a)
+    -- now a should be head
+    assert.equals("a", bucket.head.key)
+
+    -- missing key returns nil
+    assert.is_nil(Cache.getCachedAsset(bucket, "c"))
+  end)
+
+  it("getOrLoadAsset loads when missing and reuses existing", function()
+    local bucket = Cache.newBucket()
+    local loads = 0
+    local function loader()
+      loads = loads + 1
+      return 123
+    end
+
+    -- missing: should load
+    local val1 = Cache.getOrLoadAsset(bucket, "key", loader)
+    assert.equals(123, val1)
+    assert.equals(1, loads)
+
+    -- existing: should not call loader again
+    local val2 = Cache.getOrLoadAsset(bucket, "key", loader)
+    assert.equals(123, val2)
+    assert.equals(1, loads)
+  end)
+
+  it("getIsAssetCached correctly reports presence", function()
+    local bucket = Cache.newBucket()
+    assert.is_false(Cache.getIsAssetCached(bucket, "x"))
+    Cache.cacheAsset(bucket, "x", function() return true end)
+    assert.is_true(Cache.getIsAssetCached(bucket, "x"))
+  end)
+
+  it("evictAsset removes entries and rejects missing or invalid keys", function()
+    local bucket = Cache.newBucket()
+    Cache.cacheAsset(bucket, "a", function() return 1 end)
+    assert.is_true(Cache.evictAsset(bucket, "a"))
+    assert.is_false(Cache.getIsAssetCached(bucket, "a"))
+    -- evict again => false
+    assert.is_false(Cache.evictAsset(bucket, "a"))
+    -- invalid key type
+    assert.is_false(Cache.evictAsset(bucket, {}))
+  end)
+
+  it("clearCache empties the bucket", function()
+    local bucket = Cache.newBucket()
+    Cache.cacheAsset(bucket, "a", function() return 1 end)
+    assert.equals(1, bucket.currentSize)
+    assert.is_true(Cache.clearCache(bucket))
+    assert.equals(0, bucket.currentSize)
+    assert.is_nil(bucket.head)
+    assert.is_nil(bucket.tail)
+    assert.same({}, bucket.cache)
+  end)
+end)

--- a/tests/helpers/dummy_scene.lua
+++ b/tests/helpers/dummy_scene.lua
@@ -3,6 +3,7 @@
 class('Dummy').extends(RoxyScene)
 
 function Dummy:init(name, opts)
+  opts = opts or {}
   local background = opts.background or nil
   Dummy.super.init(self, background)
   self.name             = name or 'Dummy'

--- a/tests/sprite/actor_roxyactor_spec.lua
+++ b/tests/sprite/actor_roxyactor_spec.lua
@@ -101,9 +101,9 @@ describe("RoxyActor (logic unit tests)", function()
 
   it("updatePhysics chooses idle / run / jump / fall", function()
     -- helper to reset and check state quickly
-    local function expectState(props, expected)
+    local function expectState(opts, expected)
       actor.currentState = "idle"
-      actor:updatePhysics(props)
+      actor:updatePhysics(opts)
       assert.equals(expected, actor.currentState)
     end
 


### PR DESCRIPTION
### Overview
This release prepares the `roxy-engine-tests` suite for `roxy-engine` v0.8.0 by adding full test coverage for the new `Assets` and `Cache` modules. It also includes key naming refactors for consistency with engine changes, formatting cleanups, and a submodule update to the latest engine version.

### Key Changes
- Bumped `roxy-engine` submodule to v0.8.0 for asset pooling and caching support
- Added `AssetsIntegrationTest` for pool growth, reuse, and failure fallback validation
- Added `CacheIntegrationTest` for LRU cache behavior, eviction, lazy loading, and bucket logic
- Added unit tests for `Assets` and `Cache` APIs and internal logic
- Registered asset and cache tests in main scene manager and updated default start scene
- Cleaned up `RoxySpriteIntegrationTest`: removed unused code and standardized formatting
- Fixed nil access bug in Dummy scene by adding default `opts` initialization
- Renamed `props` to `opts` in `RoxyActor` test helper to match engine parameter naming
- Bumped `pdxinfo` to version 0.8.0, build 95 for consistency with engine version